### PR TITLE
Add automatic test for example script

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,36 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [ "3.10" ]
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Set Up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Test example script help message
+        run: |
+          ./scripts/run_kmeans_example.py --help
+      - name: Test example script execution
+        run: |
+          ./scripts/run_kmeans_example.py --num_clusters 5 --num_neurons 42 --device cpu --save_data_path "kmeans_test_results"
+

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -27,6 +27,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .
+      - name: Run unit tests
+        run: |
+          pytest -v
       - name: Test example script help message
         run: |
           ./scripts/run_kmeans_example.py --help

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ scikit-learn
 nnfabrik @ git+https://github.com/sinzlab/nnfabrik.git@29f22bc95841897d734532c02b77423e602ba21f
 neuralpredictors
 neuro-mei
+pytest


### PR DESCRIPTION
The test is defined as a github action and will execute the example script against python3.10 (we could also run it against multiple python version, though) as described in the README.
See an example of the running test: https://github.com/thomasZen/most-discriminative-stimuli/actions/runs/9417235104/job/25941988964

Depending on the settings of the ecker-lab organization, this test would run automatically for every commit on the main branch and on every PR.